### PR TITLE
Small changes to noise.

### DIFF
--- a/noise.py
+++ b/noise.py
@@ -164,7 +164,7 @@ class Noise:
         # Fit the data
         if scale is None:
             self.calculate_scale(method=method)  # [1] is the std. of a Gaussian
-            self.spatial_norm = np.ones(self.cube.shape[-2:])
+            self.spatial_norm = np.ones((self.cube.shape[1], self.cube.shape[2]))
             self.spectral_norm = np.ones((self.cube.shape[0]))
 
         # Compute the scale_cube
@@ -260,7 +260,7 @@ class Noise:
         negative values in the array and the MAD()
         """
         if method == "MAD":
-            data = self.cube.filled_data[:].value.astype('=f')
+            data = self.cube.flattened().value.astype('=f')
             if (data < 0).any():
                 negs = data[data < 0]
                 self.scale = mad(
@@ -482,7 +482,7 @@ class Noise:
         if verbose:
             print "Calculating overall scale."
         self.calculate_scale(method=method)
-        self.spatial_norm = np.ones(self.cube.shape[-2:])
+        self.spatial_norm = np.ones((self.cube.shape[1], self.cube.shape[2]))
         self.spectral_norm = np.ones((self.cube.shape[0]))
 
         # Iterate over spatial and spectral variations


### PR DESCRIPTION
Hello all. I've made some small changes to `Noise`.
Here is a complete description of the changes:
- allow `beam` to be an astropy 2D Kernel - allows radio_beam to be optional
- changed `scale_cube` to be a property - avoids recomputing in multiple spots
- changed `noise_cube` to be a property - not sure if this one is necessary
- If there are no negative values in the cube (ie. from a sim), revert to using `"STD"` to calculate the scale.
- added a `NaN` check to `mad`
- added additional args to `spatial_smooth` - fixes issues when calling from `estimate_noise`

@akleroy & @low-sky, please let me know if some of the changes aren't appropriate for the package. Thanks!
