### PR TITLE
Reject on region

### DIFF
--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -325,7 +325,8 @@ class RadioMask(object):
         self._mask = nd.binary_closing(self._mask, structure=struct,
                                        iterations=iterations)
 
-    def remove_small_regions(self, area_threshold=None, beam=None):
+    def remove_small_regions(self, area_threshold=None, beam=None,
+                             verbose=False):
         '''
         Remove 2D regions (per channel) based on their area. By default, this
         removed regions smaller than the beam area.
@@ -367,13 +368,13 @@ class RadioMask(object):
 
         self.reject_region(area_thresh_func, iteraxis='spectral',
                            func_args=(area_threshold),
-                           log_call=False)
+                           log_call=False, verbose=verbose)
 
         return self
 
     # Reject on property
     def reject_region(self, func, iteraxis='spectral', func_args=(),
-                      log_call=True):
+                      log_call=True, verbose=False):
         '''
         Remove 2D regions from the mask based on the given criteria.
         The specified function should operate on two-dimensional planes.
@@ -392,6 +393,8 @@ class RadioMask(object):
         log_call : bool, optional
             Turns off the logging, since this function is called within
             remove_small_regions.
+        verbose : bool, optional
+            Enabling prints out the plane currently being altered.
         '''
         if log_call:
             self.log_and_backup(self.reject_region)
@@ -410,6 +413,8 @@ class RadioMask(object):
         plane_slice = [slice(None)] * self._linked_data.wcs.naxis
         # Now iterate through the planes
         for plane in range(nplanes):
+            if verbose:
+                print("On plane "+str(plane)+" of "+str(nplanes))
             plane_slice[iteraxis] = plane
             self._mask[plane_slice] = \
                 func(self._mask[plane_slice], *func_args)

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -19,6 +19,8 @@ from spectral_cube import SpectralCube, BooleanArrayMask
 from spectral_cube.masks import is_broadcastable_and_smaller
 from radio_beam import Beam
 
+from .utils import get_pixel_scales
+
 # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
 # BASE CLASS
 # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -398,7 +398,7 @@ class RadioMask(object):
             # Eventually the unit should be included in get_pixel_scales
             # but this requires additional workarounds when used for Beam
             # objects
-            pixscale = get_pixel_scales(self._linked_data.wcs) * u.deg
+            pixscale = get_pixel_scales(self._wcs) * u.deg
             # Now get the pixel beam area
             area_threshold = (beam.sr.to(u.deg**2) / pixscale**2.).value
 
@@ -448,8 +448,8 @@ class RadioMask(object):
             self.log_and_backup(self.reject_region)
 
         if iteraxis == 'spectral':
-            iteraxis = self._linked_data.wcs.naxis - \
-                self._linked_data.wcs.wcs.spec - 1
+            iteraxis = self._wcs.naxis - \
+                self._wcs.wcs.spec - 1
         elif isinstance(iteraxis, int):
             pass
         else:
@@ -459,7 +459,7 @@ class RadioMask(object):
             func_args = (func_args, )
 
         nplanes = self.mask.shape[iteraxis]
-        plane_slice = [slice(None)] * self._linked_data.wcs.naxis
+        plane_slice = [slice(None)] * self._wcs.naxis
         # Now iterate through the planes
         for plane in range(nplanes):
             if verbose:

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -13,6 +13,7 @@ import logging
 import numpy as np
 import matplotlib.pyplot as plt
 import scipy.ndimage as nd
+from astropy import units as u
 
 # radio tools
 from spectral_cube import SpectralCube, BooleanArrayMask
@@ -350,9 +351,13 @@ class RadioMask(object):
             if beam is None:
                 beam = Beam.from_fits_header(self._linked_data.header)
 
-            pixscale = get_pixel_scales(self._linked_data.wcs)
+            # Get pixelscale, add unit on (ignore the per pixel)
+            # Eventually the unit should be included in get_pixel_scales
+            # but this requires additional workarounds when used for Beam
+            # objects
+            pixscale = get_pixel_scales(self._linked_data.wcs) * u.deg
             # Now get the pixel beam area
-            pixel_area = beam.sr / pixscale**2.
+            area_threshold = (beam.sr.to(u.deg**2) / pixscale**2.).value
 
         def area_thresh_func(arr, size_thresh):
             label_arr, num = nd.label(arr, np.ones((3, 3)))

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -345,9 +345,9 @@ class RadioMask(object):
         # Attempt to get beam area from cube WCS info.
         if area_threshold is None:
             if beam is None:
-                beam = Beam.from_fits_header(self.cube.wcs.header)
+                beam = Beam.from_fits_header(self._linked_data.header)
 
-            pixscale = get_pixel_scales(self.cube.wcs)
+            pixscale = get_pixel_scales(self._linked_data.wcs)
             # Now get the pixel beam area
             pixel_area = beam.sr / pixscale**2.
 
@@ -395,14 +395,14 @@ class RadioMask(object):
             self.log_and_backup(self.reject_region)
 
         if iteraxis == 'spectral':
-            iteraxis = self.cube.wcs.wcs.spec
+            iteraxis = self._linked_data.wcs.wcs.spec
         elif isinstance(iteraxis, int):
             pass
         else:
             raise TypeError("iteraxis must be an integer or 'spectral'.")
 
         nplanes = self.mask.shape[iteraxis]
-        plane_slice = [slice(None) * self.cube.wcs.naxis]
+        plane_slice = [slice(None) * self._linked_data.wcs.naxis]
         # Now iterate through the planes
         for plane in range(nplanes):
             plane_slice[iteraxis] = slice(plane, plane+1)

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -410,7 +410,7 @@ class RadioMask(object):
         plane_slice = [slice(None)] * self._linked_data.wcs.naxis
         # Now iterate through the planes
         for plane in range(nplanes):
-            plane_slice[iteraxis] = slice(plane, plane+1)
+            plane_slice[iteraxis] = plane
             self._mask[plane_slice] = \
                 func(self._mask[plane_slice], *func_args)
 

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -403,6 +403,9 @@ class RadioMask(object):
         else:
             raise TypeError("iteraxis must be an integer or 'spectral'.")
 
+        if not isinstance(func_args, tuple):
+            func_args = (func_args, )
+
         nplanes = self.mask.shape[iteraxis]
         plane_slice = [slice(None)] * self._linked_data.wcs.naxis
         # Now iterate through the planes

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -237,11 +237,9 @@ class RadioMask(object):
 
     def enable_backup(self):
         self.is_backup_enabled = True
-        return self
 
     def disable_backup(self):
         self.is_backup_enabled = False
-        return self
 
     def log_and_backup(self, func):
         '''

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -404,7 +404,7 @@ class RadioMask(object):
             raise TypeError("iteraxis must be an integer or 'spectral'.")
 
         nplanes = self.mask.shape[iteraxis]
-        plane_slice = [slice(None) * self._linked_data.wcs.naxis]
+        plane_slice = [slice(None)] * self._linked_data.wcs.naxis
         # Now iterate through the planes
         for plane in range(nplanes):
             plane_slice[iteraxis] = slice(plane, plane+1)

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -343,7 +343,7 @@ class RadioMask(object):
         # Attempt to get beam area from cube WCS info.
         if area_threshold is None:
             if beam is None:
-                beam = Beam.from_fits_header(self.cube.wcs.to_header())
+                beam = Beam.from_fits_header(self.cube.wcs.header)
 
             pixscale = get_pixel_scales(self.cube.wcs)
             # Now get the pixel beam area

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -97,7 +97,7 @@ class RadioMask(object):
 
     def from_spec_cube(self, cube, thresh=None):
         self._linked_data = cube
-        self._mask = cube._mask.include
+        self._mask = cube._mask.include()
         self._wcs = cube.wcs
 
     def from_array(self, array, thresh=None, wcs=None):

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -362,7 +362,8 @@ class RadioMask(object):
             return arr
 
         self.reject_region(area_thresh_func, iteraxis='spectral',
-                           func_args=(area_threshold))
+                           func_args=(area_threshold),
+                           log_call=False)
 
         return self
 

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -233,10 +233,12 @@ class RadioMask(object):
     # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
     def enable_backup(self):
-        self._implict_backup = True
+        self.is_backup_enabled = True
+        return self
 
     def disable_backup(self):
-        self._implict_backup = False
+        self.is_backup_enabled = False
+        return self
 
     def log_and_backup(self, func):
         '''

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -400,7 +400,8 @@ class RadioMask(object):
             self.log_and_backup(self.reject_region)
 
         if iteraxis == 'spectral':
-            iteraxis = self._linked_data.wcs.wcs.spec
+            iteraxis = self._linked_data.wcs.naxis - \
+                self._linked_data.wcs.wcs.spec - 1
         elif isinstance(iteraxis, int):
             pass
         else:

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -146,7 +146,7 @@ class RadioMask(object):
 
     def from_spec_cube(self, cube, thresh=None):
         self._linked_data = cube
-        self._mask = cube.mask
+        self._mask = cube.mask.include()
         self._wcs = cube.wcs
 
     def from_array(self, array, thresh=None, wcs=None):

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -101,7 +101,7 @@ class RadioMask(object):
 
     def from_spec_cube(self, cube, thresh=None):
         self._linked_data = cube
-        self._mask = cube._mask.include()
+        self._mask = cube.mask
         self._wcs = cube.wcs
 
     def from_array(self, array, thresh=None, wcs=None):

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -320,6 +320,13 @@ class RadioMask(object):
         self._mask = nd.binary_closing(self._mask, structure=struct,
                                        iterations=iterations)
 
+    def remove_small_regions(self):
+        '''
+        Remove 2D regions (per channel) based on their area. By default, this
+        removed regions smaller than the beam area.
+        '''
+        raise NotImplementedError("")
+
     # Reject on property
     def reject_region(self, func=None, thresh=None, struct=None):
         # self.log_and_backup(self.reject_region)

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -328,9 +328,41 @@ class RadioMask(object):
         raise NotImplementedError("")
 
     # Reject on property
-    def reject_region(self, func=None, thresh=None, struct=None):
-        # self.log_and_backup(self.reject_region)
-        raise NotImplementedError()
+    def reject_region(self, func, iteraxis='spectral', func_args=()):
+        '''
+        Remove 2D regions from the mask based on the given criteria.
+        The specified function should operate on two-dimensional planes.
+        The axis to be iterated over can be specified using the iteraxis
+        argument. Additional inputs should be specified as a tuple in the args
+        argument.
+
+        Parameters
+        ----------
+        func : function
+            Contains rejection criteria operating on 2D planes.
+        iteraxis : int or 'spectral', optional
+            Axis to iterate over. This defaults to the spectral axis.
+        func_args : tuple, optional
+            Arguments passed to func.
+        '''
+        self.log_and_backup(self.reject_region)
+
+        if iteraxis == 'spectral':
+            iteraxis = self.cube.wcs.wcs.spec
+        elif isinstance(iteraxis, int):
+            pass
+        else:
+            raise TypeError("iteraxis must be an integer or 'spectral'.")
+
+        nplanes = self.mask.shape[iteraxis]
+        plane_slice = [slice(None) * self.cube.wcs.naxis]
+        # Now iterate through the planes
+        for plane in range(nplanes):
+            plane_slice[iteraxis] = slice(plane, plane+1)
+            self._mask[plane_slice] = \
+                func(self._mask[plane_slice], *func_args)
+
+        return self
 
     # Reject on volume (special case)
     def reject_on_volume(self, thresh=None, struct=None):

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -341,10 +341,13 @@ class RadioMask(object):
         self.log_and_backup(self.remove_small_regions)
 
         # Attempt to get beam area from cube WCS info.
-        if area_threshold is None and beam is None:
-            pass
-        elif area_threshold is None and beam is not None:
-            pass
+        if area_threshold is None:
+            if beam is None:
+                beam = Beam.from_fits_header(self.cube.wcs.to_header())
+
+            pixscale = get_pixel_scales(self.cube.wcs)
+            # Now get the pixel beam area
+            pixel_area = beam.sr / pixscale**2.
 
         def area_thresh_func(arr, size_thresh):
             label_arr, num = nd.label(arr, np.ones((3, 3)))

--- a/signal_id/utils.py
+++ b/signal_id/utils.py
@@ -138,3 +138,18 @@ def get_pixel_scales(mywcs):
     #scale = np.array([cdelt[0] * (pc[0,0]**2 + pc[1,0]**2)**0.5,
     # cdelt[1] * (pc[0,1]**2 + pc[1,1]**2)**0.5])
     #return abs(scale[0])
+
+
+def get_celestial_axes(wcs):
+    '''
+    Return which axis or axes are celestial.
+    '''
+
+    is_celestial = []
+    axis_types = wcs.get_axis_types()
+
+    for ax in range(wcs.naxis):
+        if axis_types[ax]['coordinate_type'] == "celestial":
+            is_celestial.append(ax)
+
+    return is_celestial

--- a/signal_id/utils.py
+++ b/signal_id/utils.py
@@ -138,19 +138,3 @@ def get_pixel_scales(mywcs):
     #scale = np.array([cdelt[0] * (pc[0,0]**2 + pc[1,0]**2)**0.5,
     # cdelt[1] * (pc[0,1]**2 + pc[1,1]**2)**0.5])
     #return abs(scale[0])
-
-
-def get_celestial_axes(wcs):
-    '''
-    Return which axis or axes are celestial.
-    '''
-
-    is_celestial = []
-    axis_types = wcs.get_axis_types()
-
-    for ax in range(wcs.naxis):
-        if axis_types[ax]['coordinate_type'] == "celestial":
-            is_celestial.append(ax)
-
-    return is_celestial
-

--- a/signal_id/utils.py
+++ b/signal_id/utils.py
@@ -153,3 +153,4 @@ def get_celestial_axes(wcs):
             is_celestial.append(ax)
 
     return is_celestial
+


### PR DESCRIPTION
Remove regions in the plane which are smaller than the beam area. This builds off of the more general ```reject_region```, which I also implemented here. I assumed that the roughed-in description meant it was for general handling of 2D rejection criteria.