### PR TITLE
Fix writing out masks

### DIFF
--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -186,7 +186,13 @@ class RadioMask(object):
 
     def as_spec_cube(self, dtype=bool):
         """
-        Return a spectral cube. Use scale to change type.
+        Return a spectral cube.
+
+        Parameters
+        ----------
+        dtype : valid data type, optional
+            Specify the data type to be used in the mask in the
+            SpectralCube object. Defaults to boolean.
         """
         if isinstance(self._linked_data, SpectralCube):
             return SpectralCube(self._mask.astype(dtype),
@@ -205,6 +211,14 @@ class RadioMask(object):
     def write(self, fname, dtype=int):
         """
         Write to a file. Default to using ints.
+
+        Parameters
+        ----------
+        fname : str
+            Name of the file to output to.
+        dtype : valid data type, optional
+            The data type the mask is converted to when writing out. Due to
+            FITS not supporting boolean arrays, the default is 'int'.
         """
         # So wasteful...
         cube = self.as_spec_cube(dtype=dtype)

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -184,14 +184,14 @@ class RadioMask(object):
         """
         return copy.deepcopy(self)
 
-    def as_spec_cube(self, scale=True):
+    def as_spec_cube(self, dtype=bool):
         """
         Return a spectral cube. Use scale to change type.
         """
         if isinstance(self._linked_data, SpectralCube):
-            return SpectralCube(self._mask*scale,
+            return SpectralCube(self._mask.astype(dtype),
                                 wcs=self._wcs)
-        return SpectralCube(self._mask*scale,
+        return SpectralCube(self._mask.astype(dtype),
                             wcs=self._wcs)
 
     def to_mask(self):
@@ -202,12 +202,12 @@ class RadioMask(object):
         copy_mask.invert()
         return BooleanArrayMask(self._mask, self._wcs)
 
-    def write(self, fname, scale=1):
+    def write(self, fname, dtype=int):
         """
         Write to a file. Default to using ints.
         """
         # So wasteful...
-        cube = self.as_spec_cube(self, scale=scale)
+        cube = self.as_spec_cube(dtype=dtype)
         cube.write(fname)
 
     def attach_to_cube(self, cube=None, empty=np.NaN):


### PR DESCRIPTION
```as_spec_cube``` was being called incorrectly.

I changed ```scale``` to ```dtype``` in order to set the data type of the array fed into ```SpectralCube```. 