### PR TITLE
Check cube for beam

### DIFF
--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -115,7 +115,7 @@ class RadioMask(object):
         if isinstance(data, SpectralCube):
                 self.from_spec_cube(data, thresh=thresh, *args)
 
-        elif isinstance(data, str):
+        elif isinstance(data, str) or isinstance(data, unicode):
             self.from_file(data, *args)
 
         elif isinstance(data, np.ndarray):

--- a/signal_id/mask.py
+++ b/signal_id/mask.py
@@ -14,6 +14,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import scipy.ndimage as nd
 from astropy import units as u
+from astropy.extern import six
 
 # radio tools
 from spectral_cube import SpectralCube, BooleanArrayMask
@@ -115,7 +116,7 @@ class RadioMask(object):
         if isinstance(data, SpectralCube):
                 self.from_spec_cube(data, thresh=thresh, *args)
 
-        elif isinstance(data, str) or isinstance(data, unicode):
+        elif isinstance(data, six.string_types):
             self.from_file(data, *args)
 
         elif isinstance(data, np.ndarray):

--- a/signal_id/noise.py
+++ b/signal_id/noise.py
@@ -114,14 +114,8 @@ class Noise(object):
     # Initialization
     # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
-    def __init__(
-        self,
-        cube,
-        scale=None,
-        spatial_norm = None,
-        spectral_norm = None,
-        beam = None,
-        method="MAD"):
+    def __init__(self, cube, scale=None, spatial_norm=None,
+                 spectral_norm=None, beam=None, method="MAD"):
         """
         Construct a new Noise object.
 

--- a/signal_id/noise.py
+++ b/signal_id/noise.py
@@ -140,12 +140,11 @@ class Noise(object):
         if beam is None:
             try:
                 self.beam = cube.beam
-                self.astropy_beam_flag = False
             except AttributeError:
                 warnings.warn("cube object has no associated beam. All beam "
                               "operations are disabled.")
                 self.beam = None
-                self.astropy_beam_flag = True
+            self.astropy_beam_flag = False
         else:
             if isinstance(beam, Beam):
                 self.astropy_beam_flag = False

--- a/signal_id/noise.py
+++ b/signal_id/noise.py
@@ -135,16 +135,27 @@ class Noise(object):
         else:
             warnings.warn("Noise currently requires a SpectralCube instance.")
 
-        self.spatial_footprint = np.any(self.cube.get_mask_array(),axis=0)
+        self.spatial_footprint = np.any(self.cube.get_mask_array(), axis=0)
 
-        if isinstance(beam, Beam):
-            self.astropy_beam_flag = False
-        elif isinstance(beam, Kernel2D):
-            self.astropy_beam_flag = True
+        if beam is None:
+            try:
+                self.beam = cube.beam
+                self.astropy_beam_flag = False
+            except AttributeError:
+                warnings.warn("cube object has no associated beam. All beam "
+                              "operations are disabled.")
+                self.beam = None
+                self.astropy_beam_flag = True
         else:
-            warnings.warn("beam must be a radio_beam Beam object or an astropy\
-                           Kernel2D object. All beam operations are disabled.")
-        self.beam = beam
+            if isinstance(beam, Beam):
+                self.astropy_beam_flag = False
+            elif isinstance(beam, Kernel2D):
+                self.astropy_beam_flag = True
+            else:
+                warnings.warn("beam must be a radio_beam Beam object or an "
+                              "astropy Kernel2D object. All beam operations "
+                              "are disabled.")
+            self.beam = beam
 
         # Default to a normal distribution
         self.distribution = ss.norm


### PR DESCRIPTION
Since spectral-cubes should have an attached ```Beam``` whenever it is defined in the header, ```Noise``` should automatically check for and use it.

Also includes an old commit to check for unicode strings when loading with ```Radio_Mask```.